### PR TITLE
git: to https:

### DIFF
--- a/envs/hydro.yaml
+++ b/envs/hydro.yaml
@@ -19,5 +19,5 @@ dependencies:
     - cdsapi=0.1.4
     - pycountry=18.12.8
     - pip:
-        - git+git://github.com/FRESNA/atlite.git@ecfd3f3eb380efa00d0b6bc7efa4a8b20e40dc34
+        - git+https://github.com/FRESNA/atlite.git@ecfd3f3eb380efa00d0b6bc7efa4a8b20e40dc34
 


### PR DESCRIPTION
Does what it says on the tin. GitHub's [current recommendation](https://help.github.com/en/github/using-git/which-remote-url-should-i-use) is to use the 'https' URL for cloning repositories. But, besides that, it's a lot easier to work with on a cluster compute node. using the 'git:' URL certainly didn't work for me (either a credential issue, or some blocking of SSH on those nodes).

