### PR TITLE
Fix hydro inflow

### DIFF
--- a/src/hydro/inflow_mwh.py
+++ b/src/hydro/inflow_mwh.py
@@ -88,8 +88,15 @@ def water_to_capped_energy_inflow(inflow_m3, annual_generation, cap):
 
 
 def allocate_generation_to_plant(plants, annual_national_generation_mwh):
+    inflows = plants.inflow_m3.to_pandas()
     plants = plants[["country_code", "installed_capacity_MW"]].to_dataframe()
-    capacity_share = plants.groupby("country_code")["installed_capacity_MW"].transform(lambda x: x / x.sum())
+
+    # Capacity share is scaled to account for erroneous zero timesteps in the inflow data
+    inflow_count = inflows.where(inflows > 1).count(axis=1) / inflows.count(axis=1)
+    capacity_share = plants.assign(
+        scaled_capacity=plants.installed_capacity_MW.multiply(inflow_count)
+    ).groupby("country_code")["scaled_capacity"].transform(lambda x: x / x.sum())
+
     national_generation = (
         plants.reset_index()
               .merge(annual_national_generation_mwh, on="country_code", how="left", validate="many_to_one")

--- a/src/hydro/inflow_mwh.py
+++ b/src/hydro/inflow_mwh.py
@@ -88,7 +88,7 @@ def water_to_capped_energy_inflow(inflow_m3, annual_generation, cap):
 
 
 def allocate_generation_to_plant(plants, annual_national_generation_mwh):
-    inflows = plants.inflow_m3.to_pandas()
+    inflows = plants.inflow_m3.to_pandas().fillna(0)
     plants = plants[["country_code", "installed_capacity_MW"]].to_dataframe()
 
     # Capacity share is scaled to account for erroneous zero timesteps in the inflow data


### PR DESCRIPTION
This is the main part of the previously closed PR #1. From that PR: 

It's clear from the data that instances of zero inflow are erroneous (when the data in timesteps either side is >x10^4). I've dealt with this by rescaling capacities based on the percentage of timesteps in which inflow is non-zero, when calculating the capacity share. It's possibly a bit of a hack, but no more so than the existing method ;)