### PR TITLE
Update hydro data path

### DIFF
--- a/rules/hydro.smk
+++ b/rules/hydro.smk
@@ -14,7 +14,7 @@ rule download_runoff_data:
         src = "src/hydro/runoff.py"
     params: year = config["year"]
     output:
-        protected(directory("data/automatic/europe-cutout"))
+        protected(directory("data/automatic/europe-cutout.{}".format(config["year"])))
     conda: "../envs/hydro.yaml"
     script: "../src/hydro/runoff.py"
 


### PR DESCRIPTION
It takes a a reasonable amount of time to get the hydro runoff data from Copernicus, so it might be better to store annual data locally, such that switching between years and rerunning the snakemake workflow doesn't require the data to be freshly downloaded. This also deals with the current issue that running for a different year requires manually deleting the 'europe-cutout' directory, since it's protected.